### PR TITLE
Fix daemon crash on malformed NamedTuple (#14119)

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -724,7 +724,7 @@ achieved by combining with :py:func:`@overload <typing.overload>`:
 
 .. code-block:: python
 
-    from typing import Any, Callable, TypeVar, overload
+    from typing import Any, Callable, Optional, TypeVar, overload
 
     F = TypeVar('F', bound=Callable[..., Any])
 
@@ -736,7 +736,7 @@ achieved by combining with :py:func:`@overload <typing.overload>`:
     def atomic(*, savepoint: bool = True) -> Callable[[F], F]: ...
 
     # Implementation
-    def atomic(__func: Callable[..., Any] = None, *, savepoint: bool = True):
+    def atomic(__func: Optional[Callable[..., Any]] = None, *, savepoint: bool = True):
         def decorator(func: Callable[..., Any]):
             ...  # Code goes here
         if __func is not None:

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -635,7 +635,7 @@ Before parameter specifications, here's how one might have annotated the decorat
 
 .. code-block:: python
 
-   from typing import Callable, TypeVar
+   from typing import Any, Callable, TypeVar, cast
 
    F = TypeVar('F', bound=Callable[..., Any])
 
@@ -650,8 +650,8 @@ and that would enable the following type checks:
 
 .. code-block:: python
 
-   reveal_type(a)  # str
-   add_forty_two('x')    # Type check error: incompatible type "str"; expected "int"
+   reveal_type(a)  # Revealed type is "builtins.int"
+   add_forty_two('x')  # Argument 1 to "add_forty_two" has incompatible type "str"; expected "int"
 
 
 Note that the ``wrapper()`` function is not type-checked. Wrapper

--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -187,6 +187,7 @@ def main() -> None:
     commits_to_cherry_pick = [
         "780534b13722b7b0422178c049a1cbbf4ea4255b",  # LiteralString reverts
         "5319fa34a8004c1568bb6f032a07b8b14cc95bed",  # sum reverts
+        "0062994228fb62975c6cef4d2c80d00c7aa1c545",  # ctypes reverts
     ]
     for commit in commits_to_cherry_pick:
         subprocess.run(["git", "cherry-pick", commit], check=True)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -806,6 +806,7 @@ class FreezeTypeVarsVisitor(TypeTraverserVisitor):
     def visit_callable_type(self, t: CallableType) -> None:
         for v in t.variables:
             v.id.meta_level = 0
+        super().visit_callable_type(t)
 
 
 def lookup_member_var_or_accessor(info: TypeInfo, name: str, is_lvalue: bool) -> SymbolNode | None:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1068,6 +1068,7 @@ class ClassDef(Statement):
         "analyzed",
         "has_incompatible_baseclass",
         "deco_line",
+        "removed_statements",
     )
 
     __match_args__ = ("name", "defs")
@@ -1086,6 +1087,8 @@ class ClassDef(Statement):
     keywords: dict[str, Expression]
     analyzed: Expression | None
     has_incompatible_baseclass: bool
+    # Used by special forms like NamedTuple and TypedDict to store invalid statements
+    removed_statements: list[Statement]
 
     def __init__(
         self,
@@ -1111,6 +1114,7 @@ class ClassDef(Statement):
         self.has_incompatible_baseclass = False
         # Used for error reporting (to keep backwad compatibility with pre-3.8)
         self.deco_line: int | None = None
+        self.removed_statements = []
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_class_def(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1448,7 +1448,13 @@ class SemanticAnalyzer(
                 dec.var.is_classmethod = True
                 self.check_decorated_function_is_method("classmethod", dec)
             elif refers_to_fullname(
-                d, ("builtins.property", "abc.abstractproperty", "functools.cached_property")
+                d,
+                (
+                    "builtins.property",
+                    "abc.abstractproperty",
+                    "functools.cached_property",
+                    "enum.property",
+                ),
             ):
                 removed.append(i)
                 dec.func.is_property = True

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -283,9 +283,11 @@ class TypedDictAnalyzer:
                 ):
                     statements.append(stmt)
                 else:
+                    defn.removed_statements.append(stmt)
                     self.fail(TPDICT_CLASS_ERROR, stmt)
             elif len(stmt.lvalues) > 1 or not isinstance(stmt.lvalues[0], NameExpr):
                 # An assignment, but an invalid one.
+                defn.removed_statements.append(stmt)
                 self.fail(TPDICT_CLASS_ERROR, stmt)
             else:
                 name = stmt.lvalues[0].name

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -140,6 +140,8 @@ class NodeStripVisitor(TraverserVisitor):
         ]
         with self.enter_class(node.info):
             super().visit_class_def(node)
+        node.defs.body.extend(node.removed_statements)
+        node.removed_statements = []
         TypeState.reset_subtype_caches_for(node.info)
         # Kill the TypeInfo, since there is none before semantic analysis.
         node.info = CLASSDEF_NO_INFO

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -31,6 +31,7 @@ from mypy.types import (
     UninhabitedType,
     UnionType,
     get_proper_type,
+    has_recursive_types,
 )
 
 
@@ -156,6 +157,12 @@ class TypesSuite(Suite):
         assert C.expand_all_if_possible() == TupleType(
             [self.fx.a, self.fx.a], Instance(self.fx.std_tuplei, [self.fx.a])
         )
+
+    def test_recursive_nested_in_non_recursive(self) -> None:
+        A, _ = self.fx.def_alias_1(self.fx.a)
+        NA = self.fx.non_rec_alias(Instance(self.fx.gi, [UnboundType("T")]), ["T"], [A])
+        assert not NA.is_recursive
+        assert has_recursive_types(NA)
 
     def test_indirection_no_infinite_recursion(self) -> None:
         A, _ = self.fx.def_alias_1(self.fx.a)

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -339,9 +339,13 @@ class TypeFixture:
         A.alias = AN
         return A, target
 
-    def non_rec_alias(self, target: Type) -> TypeAliasType:
-        AN = TypeAlias(target, "__main__.A", -1, -1)
-        return TypeAliasType(AN, [])
+    def non_rec_alias(
+        self, target: Type, alias_tvars: list[str] | None = None, args: list[Type] | None = None
+    ) -> TypeAliasType:
+        AN = TypeAlias(target, "__main__.A", -1, -1, alias_tvars=alias_tvars)
+        if args is None:
+            args = []
+        return TypeAliasType(AN, args)
 
 
 class InterfaceTypeFixture(TypeFixture):

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -450,7 +450,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         if fullname == "builtins.None":
             return NoneType()
         elif fullname == "typing.Any" or fullname == "builtins.Any":
-            return AnyType(TypeOfAny.explicit)
+            return AnyType(TypeOfAny.explicit, line=t.line, column=t.column)
         elif fullname in FINAL_TYPE_NAMES:
             self.fail(
                 "Final can be only used as an outermost qualifier in a variable annotation",

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -278,30 +278,42 @@ class TypeAliasType(Type):
             self.alias.target, self.alias.alias_tvars, self.args, self.line, self.column
         )
 
-    def _partial_expansion(self) -> tuple[ProperType, bool]:
+    def _partial_expansion(self, nothing_args: bool = False) -> tuple[ProperType, bool]:
         # Private method mostly for debugging and testing.
         unroller = UnrollAliasVisitor(set())
-        unrolled = self.accept(unroller)
+        if nothing_args:
+            alias = self.copy_modified(args=[UninhabitedType()] * len(self.args))
+        else:
+            alias = self
+        unrolled = alias.accept(unroller)
         assert isinstance(unrolled, ProperType)
         return unrolled, unroller.recursed
 
-    def expand_all_if_possible(self) -> ProperType | None:
+    def expand_all_if_possible(self, nothing_args: bool = False) -> ProperType | None:
         """Attempt a full expansion of the type alias (including nested aliases).
 
         If the expansion is not possible, i.e. the alias is (mutually-)recursive,
-        return None.
+        return None. If nothing_args is True, replace all type arguments with an
+        UninhabitedType() (used to detect recursively defined aliases).
         """
-        unrolled, recursed = self._partial_expansion()
+        unrolled, recursed = self._partial_expansion(nothing_args=nothing_args)
         if recursed:
             return None
         return unrolled
 
     @property
     def is_recursive(self) -> bool:
+        """Whether this type alias is recursive.
+
+        Note this doesn't check generic alias arguments, but only if this alias
+        *definition* is recursive. The property value thus can be cached on the
+        underlying TypeAlias node. If you want to include all nested types, use
+        has_recursive_types() function.
+        """
         assert self.alias is not None, "Unfixed type alias"
         is_recursive = self.alias._is_recursive
         if is_recursive is None:
-            is_recursive = self.expand_all_if_possible() is None
+            is_recursive = self.expand_all_if_possible(nothing_args=True) is None
             # We cache the value on the underlying TypeAlias node as an optimization,
             # since the value is the same for all instances of the same alias.
             self.alias._is_recursive = is_recursive
@@ -3259,7 +3271,7 @@ class HasRecursiveType(TypeQuery[bool]):
         super().__init__(any)
 
     def visit_type_alias_type(self, t: TypeAliasType) -> bool:
-        return t.is_recursive
+        return t.is_recursive or self.query_types(t.args)
 
 
 def has_recursive_types(typ: Type) -> bool:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -520,7 +520,11 @@ def parse_gray_color(cup: bytes) -> str:
 
 
 def should_force_color() -> bool:
-    return bool(int(os.getenv("MYPY_FORCE_COLOR", os.getenv("FORCE_COLOR", "0"))))
+    env_var = os.getenv("MYPY_FORCE_COLOR", os.getenv("FORCE_COLOR", "0"))
+    try:
+        return bool(int(env_var))
+    except ValueError:
+        return bool(env_var)
 
 
 class FancyFormatter:

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -393,8 +393,6 @@ class X(typing.NamedTuple):
 [out]
 main:6: error: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]"
 main:7: error: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]"
-main:7: error: Type cannot be declared in assignment to non-self attribute
-main:7: error: "int" has no attribute "x"
 main:9: error: Non-default NamedTuple fields cannot follow default fields
 
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6334,3 +6334,17 @@ reveal_type(D().meth)
 [out2]
 tmp/m.py:4: note: Revealed type is "def [Self <: lib.C] (self: Self`0, other: Self`0) -> Self`0"
 tmp/m.py:5: note: Revealed type is "def (other: m.D) -> m.D"
+
+[case testIncrementalNestedGenericCallableCrash]
+from typing import TypeVar, Callable
+
+T = TypeVar("T")
+
+class B:
+    def foo(self) -> Callable[[T], T]: ...
+
+class C(B):
+    def __init__(self) -> None:
+        self.x = self.foo()
+[out]
+[out2]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10205,3 +10205,75 @@ C
 [builtins fixtures/dict.pyi]
 [out]
 ==
+
+[case testNamedTupleNestedCrash]
+import m
+[file m.py]
+from typing import NamedTuple
+
+class NT(NamedTuple):
+    class C: ...
+    x: int
+    y: int
+
+[file m.py.2]
+from typing import NamedTuple
+
+class NT(NamedTuple):
+    class C: ...
+    x: int
+    y: int
+# change
+[builtins fixtures/tuple.pyi]
+[out]
+m.py:4: error: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]"
+==
+m.py:4: error: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]"
+
+[case testNamedTupleNestedClassRecheck]
+import n
+[file n.py]
+import m
+x: m.NT
+[file m.py]
+from typing import NamedTuple
+from f import A
+
+class NT(NamedTuple):
+    class C: ...
+    x: int
+    y: A
+
+[file f.py]
+A = int
+[file f.py.2]
+A = str
+[builtins fixtures/tuple.pyi]
+[out]
+m.py:5: error: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]"
+==
+m.py:5: error: Invalid statement in NamedTuple definition; expected "field_name: field_type [= default]"
+
+[case testTypedDictNestedClassRecheck]
+import n
+[file n.py]
+import m
+x: m.TD
+[file m.py]
+from typing_extensions import TypedDict
+from f import A
+
+class TD(TypedDict):
+    class C: ...
+    x: int
+    y: A
+
+[file f.py]
+A = int
+[file f.py.2]
+A = str
+[builtins fixtures/dict.pyi]
+[out]
+m.py:5: error: Invalid statement in TypedDict definition; expected "field_name: field_type"
+==
+m.py:5: error: Invalid statement in TypedDict definition; expected "field_name: field_type"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1712,3 +1712,26 @@ A = Type[int] | str
 B: TypeAlias = Type[int] | str
 [out]
 m.pyi:5: note: Revealed type is "typing._SpecialForm"
+
+[case testEnumNameWorkCorrectlyOn311]
+# flags: --python-version 3.11
+import enum
+
+class E(enum.Enum):
+    X = 1
+    Y = 2
+    @enum.property
+    def foo(self) -> int: ...
+
+e: E
+reveal_type(e.name)
+reveal_type(e.value)
+reveal_type(E.X.name)
+reveal_type(e.foo)
+reveal_type(E.Y.foo)
+[out]
+_testEnumNameWorkCorrectlyOn311.py:11: note: Revealed type is "builtins.str"
+_testEnumNameWorkCorrectlyOn311.py:12: note: Revealed type is "Union[Literal[1]?, Literal[2]?]"
+_testEnumNameWorkCorrectlyOn311.py:13: note: Revealed type is "Literal['X']?"
+_testEnumNameWorkCorrectlyOn311.py:14: note: Revealed type is "builtins.int"
+_testEnumNameWorkCorrectlyOn311.py:15: note: Revealed type is "builtins.int"

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -103,6 +103,28 @@ class A(object):
 </body>
 </html>
 
+[case testNoCrashRecursiveAliasInReport]
+# cmd: mypy --any-exprs-report report n.py
+
+[file n.py]
+from typing import Union, List, Any, TypeVar
+
+Nested = List[Union[Any, Nested]]
+T = TypeVar("T")
+NestedGen = List[Union[T, NestedGen[T]]]
+
+x: Nested
+y: NestedGen[int]
+z: NestedGen[Any]
+
+[file report/any-exprs.txt]
+[outfile report/types-of-anys.txt]
+ Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form   Implementation Artifact
+-----------------------------------------------------------------------------------------------------------------
+    n             0          4            0                  8       0              0                         0
+-----------------------------------------------------------------------------------------------------------------
+Total             0          4            0                  8       0              0                         0
+
 [case testTypeVarTreatedAsEmptyLine]
 # cmd: mypy --html-report report n.py
 
@@ -480,7 +502,7 @@ namespace_packages = True
 <link rel="stylesheet" type="text/css" href="../../../mypy-html.css">
 </head>
 <body>
-<h2>folder.subfolder.something</h2>           
+<h2>folder.subfolder.something</h2>
 <table>
 <caption>folder/subfolder/something.py</caption>
 <tbody><tr>

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ flake8==5.0.4           # must match version in .pre-commit-config.yaml
 flake8-bugbear==22.9.23 # must match version in .pre-commit-config.yaml
 flake8-noqa==1.2.9      # must match version in .pre-commit-config.yaml
 isort[colors]==5.10.1   # must match version in .pre-commit-config.yaml
-lxml>=4.4.0; python_version<'3.11'
+lxml>=4.9.1
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10
 pytest>=6.2.4


### PR DESCRIPTION
Fixes #14098 

Having invalid statements in a NamedTuple is almost like a syntax error, we can remove them after giving an error (without further analysis). This PR does almost exactly the same as
https://github.com/python/mypy/pull/13963 did for TypedDicts.

Co-authored-by: Shantanu <12621235+hauntsaninja@users.noreply.github.com>

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
